### PR TITLE
hotwire-reloadをinstallし動作確認を実施

### DIFF
--- a/line/Gemfile
+++ b/line/Gemfile
@@ -88,6 +88,8 @@ group :development do
   # gem "spring"
 
   gem "error_highlight", ">= 0.4.0", platforms: [:ruby]
+
+  gem "hotwire-livereload", "~> 1.2"
 end
 
 group :test do

--- a/line/Gemfile.lock
+++ b/line/Gemfile.lock
@@ -130,6 +130,10 @@ GEM
       romaji
     globalid (1.2.1)
       activesupport (>= 6.1)
+    hotwire-livereload (1.3.0)
+      actioncable (>= 6.0.0)
+      listen (>= 3.0.0)
+      railties (>= 6.0.0)
     htmlbeautifier (1.4.2)
     htmlentities (4.3.4)
     i18n (1.14.1)
@@ -194,6 +198,8 @@ GEM
       net-protocol
     nio4r (2.5.9)
     nokogiri (1.15.4-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.15.4-x86_64-linux)
       racc (~> 1.4)
     parser (3.2.2.4)
       ast (~> 2.4.1)
@@ -290,6 +296,7 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     sqlite3 (1.6.7-x86_64-darwin)
+    sqlite3 (1.6.7-x86_64-linux)
     stimulus-rails (1.3.0)
       railties (>= 6.0.0)
     stringio (3.0.8)
@@ -329,6 +336,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   annotate
@@ -341,6 +349,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   gimei
+  hotwire-livereload (~> 1.2)
   importmap-rails
   jbuilder
   jquery-rails

--- a/line/app/views/layouts/application.html.erb
+++ b/line/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
+    <%= hotwire_livereload_tags if Rails.env.development? %>
   </head>
 
   <body>

--- a/line/config/cable.yml
+++ b/line/config/cable.yml
@@ -1,6 +1,7 @@
 development:
-  adapter: redis
-  url: redis://localhost:6379/1
+  # adapter: redis
+  # url: redis://localhost:6379/1
+  adapter: async
 
 test:
   adapter: test


### PR DESCRIPTION
- action-cableを使用したfrontのhot-reloadの設定を追加した

監視対象のファイルを変更し、保存するごとにreloadが走って変更を反映してくれる。
redisが依存となっている。
開発環境でしか使わないので  async で使用